### PR TITLE
fix: fix title bar and clear input search rooms icon

### DIFF
--- a/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
+++ b/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
@@ -15,6 +15,7 @@ export class SuggestionsRooms extends Component {
       listening: false,     // check if input search has event listener
       focused: -1,          // handles list items focus,
       filled: false,
+      clear: false,         // handles when to show the clear input text button
     };
     this.container = null;
     this.input = null;
@@ -80,24 +81,23 @@ export class SuggestionsRooms extends Component {
       this.setState({
         filteredRooms: [],
         filled: false,
+        clear: false,
       });
+      if (this.state.listening) {
+        this.removeInputListener();
+      }
       return;
     }
     let suggestionsList = this.state.suggestionsList;
     suggestionsList = suggestionsList.filter(item =>
       item.name.toLowerCase().search(e.target.value.toLowerCase()) !== -1
     );
-    if (target.value !== '') {
-      if (!this.state.listening) {
-        this.addInputListener();
-      }
-    } else if (target.value === '') {
-      if (this.state.listening) {
-        this.removeInputListener();
-      }
+    if (!this.state.listening) {
+      this.addInputListener();
     }
     this.setState({
       filteredRooms: suggestionsList,
+      clear: true,
     });
   }
 
@@ -178,6 +178,7 @@ export class SuggestionsRooms extends Component {
     this.setState({
       filteredRooms: [],
       focused: -1,
+      clear: false,
     });
     this.input.value = '';
     this.input.focus();
@@ -249,7 +250,10 @@ export class SuggestionsRooms extends Component {
               ref={(input) => { this.input = input; }}
               placeholder={this.props.loading ? 'Loading...' : 'Search rooms'}
             />
-            <button onClick={this.clearInput}>
+            <button
+              className={this.state.clear ? 'visible' : 'hidden'}
+              onClick={this.clearInput}
+            >
               <i className='fa fa-times' />
             </button>
           </div>

--- a/components/PostingLocation/SuggestionsRooms/styles/styles.less
+++ b/components/PostingLocation/SuggestionsRooms/styles/styles.less
@@ -41,6 +41,9 @@
         background: none;
         border: none;
         cursor: pointer;
+
+        &.visible { display: flex }
+        &.hidden { display: none }
       }
     }
 

--- a/index.jsx
+++ b/index.jsx
@@ -87,10 +87,11 @@ const dependencies = [
 
 /*
 * register                                  register application on symphony client
-* @params       services                    additional services for each integration. (Optional)
+* @params       SYMPHONY                    global variable SYMPHONY returned from SYMPHONY api
+* @params       appTitle                    title that should be shown on title bar
 * @return       SYMPHONY.remote.hello       returns a SYMPHONY remote hello service.
 */
-export const register = (SYMPHONY, services) => {
+export const register = (SYMPHONY, appTitle) => {
   // create our own service
   const listService = SYMPHONY.services.register(`${params.appId}:controller`);
   function registerApplication() {
@@ -117,7 +118,7 @@ export const register = (SYMPHONY, services) => {
         // invoke the module service to show our own application in the grid
         modulesService.show(
           params.appId,
-          { title: factory.getParams.appTitle },
+          { title: appTitle },
           `${params.appId}:controller`,
           url.join(''),
           { canFloat: true },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-integration-commons",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Common components for 3rd party developers build the user facing application for Symphony Integrations.",
   "main": "./dist/index.js",
   "scripts": {

--- a/samples/out-of-the-box-configurator/js/controller.js
+++ b/samples/out-of-the-box-configurator/js/controller.js
@@ -1,8 +1,10 @@
 import 'babel-polyfill';
 import { register } from 'symphony-integration-commons';
+import config from './config.service';
 
 /*
 * register                          invokes the register function from App-Commons module
 * @param          SYMPHONY          Global SYMPHONY object
+* @param          appTitle          The app title should appear in the title bar
 */
-register(SYMPHONY);
+register(SYMPHONY, config.appTitle);

--- a/samples/posting-location-sample/js/controller.js
+++ b/samples/posting-location-sample/js/controller.js
@@ -1,8 +1,10 @@
 import 'babel-polyfill';
 import { register } from 'symphony-integration-commons';
+import config from './config.service';
 
 /*
 * register                          invokes the register function from App-Commons module
 * @param          SYMPHONY          Global SYMPHONY object
+* @param          appTitle          The app title should appear in the title bar
 */
-register(SYMPHONY);
+register(SYMPHONY, config.appTitle);

--- a/samples/posting-location-sample/package.json
+++ b/samples/posting-location-sample/package.json
@@ -51,7 +51,7 @@
     "react-router": "^3.0.2",
     "redux": "^3.6.0",
     "redux-saga": "^0.14.3",
-    "symphony-integration-commons": "file:///home/pdarde/symphony/app/App-Integrations-FE-Commons/"
+    "symphony-integration-commons": "^0.1.1"
   },
   "repository": {
     "type": "git",

--- a/samples/posting-location-sample/package.json
+++ b/samples/posting-location-sample/package.json
@@ -51,7 +51,7 @@
     "react-router": "^3.0.2",
     "redux": "^3.6.0",
     "redux-saga": "^0.14.3",
-    "symphony-integration-commons": "0.1.1"
+    "symphony-integration-commons": "file:///home/pdarde/symphony/app/App-Integrations-FE-Commons/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes for this PR.

1. Integration title was hidden. Now, we can see the integration title in the title bar.
2. In the suggestions rooms component, the "clear" icon only should appear when we start typing.