### PR TITLE
APP-1188: fixed an already assigned room showing on suggestion lists …

### DIFF
--- a/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
+++ b/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
@@ -50,20 +50,15 @@ export class SuggestionsRooms extends Component {
 
   removeDuplicateFilter() {
     let _filters = this.props.filters;
+    let seen = {};
 
-    if(_filters.length > 0) {
-      _filters.sort();
-      for(let i = 0, n = _filters.length; i < n-1; i++) {
-        if(_filters[i].threadId == _filters[i+1].threadId) {
-          _filters.splice(i,1);
-          i--;
-          n--;
-        }
-      }
-      this.setState({
-        filters: _filters,
-      });
-    }
+    let uniqueArray = _filters.filter(item => {
+      return seen.hasOwnProperty(item.threadId) ? false : (seen[item.threadId] = true);
+    });
+
+    this.setState({
+      filters: uniqueArray,
+    });
   }
 
   setupSuggestionsList() {
@@ -130,18 +125,18 @@ export class SuggestionsRooms extends Component {
     }
     //Remove rooms already filtered from suggestions
     let currentFilters = this.state.filters;
-    for(let i = 0, n = suggestionsList.length; i < n; i++) {
-      for(let k = 0, l = currentFilters.length; k < l; k++) {
-        if(suggestionsList[i].threadId == currentFilters[k].threadId)
-        {
-          suggestionsList.splice(i,1);
-          i--;
-          n--;
-        }
-      }
+    let currentFiltersHashTable = {}
+
+    for(let i = 0; i < currentFilters.length; i ++) {
+      currentFiltersHashTable[currentFilters[i].threadId] = currentFilters[i];
     }
+
+    let uniqueArray = suggestionsList.filter(item => {
+      return !(currentFiltersHashTable.hasOwnProperty(item.threadId));
+    })
+
     this.setState({
-      filteredRooms: suggestionsList,
+      filteredRooms: uniqueArray,
       clear: true,
     });
   }

--- a/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
+++ b/components/PostingLocation/SuggestionsRooms/SuggestionsRooms.jsx
@@ -33,6 +33,7 @@ export class SuggestionsRooms extends Component {
 
   componentWillMount() {
     this.setupSuggestionsList();
+    this.removeDuplicateFilter();
   }
 
   componentDidMount() {
@@ -43,6 +44,24 @@ export class SuggestionsRooms extends Component {
     if (nextProps.userRooms !== this.props.userRooms) {
       this.setState({
         suggestionsList: nextProps.userRooms.slice(),
+      });
+    }
+  }
+
+  removeDuplicateFilter() {
+    let _filters = this.props.filters;
+
+    if(_filters.length > 0) {
+      _filters.sort();
+      for(let i = 0, n = _filters.length; i < n-1; i++) {
+        if(_filters[i].threadId == _filters[i+1].threadId) {
+          _filters.splice(i,1);
+          i--;
+          n--;
+        }
+      }
+      this.setState({
+        filters: _filters,
       });
     }
   }
@@ -108,6 +127,18 @@ export class SuggestionsRooms extends Component {
     );
     if (!this.state.listening) {
       this.addInputListener();
+    }
+    //Remove rooms already filtered from suggestions
+    let currentFilters = this.state.filters;
+    for(let i = 0, n = suggestionsList.length; i < n; i++) {
+      for(let k = 0, l = currentFilters.length; k < l; k++) {
+        if(suggestionsList[i].threadId == currentFilters[k].threadId)
+        {
+          suggestionsList.splice(i,1);
+          i--;
+          n--;
+        }
+      }
     }
     this.setState({
       filteredRooms: suggestionsList,
@@ -207,11 +238,10 @@ export class SuggestionsRooms extends Component {
         postingLocationRoom = suggestions.splice(idx, 1)[0];
       }
     });
-
     this.setState({
       filteredRooms: [],
       focused: -1,
-      filters: this.state.filters.concat([filter]),
+      filters: this.state.filters.concat(filter),
       suggestionsList: suggestions.slice(),
       filled: true,
       clear: false,

--- a/components/SubmitInstance/SubmitInstance.jsx
+++ b/components/SubmitInstance/SubmitInstance.jsx
@@ -96,25 +96,6 @@ export class SubmitInstance extends Component {
       ) {
         return;
       }
-
-      let _postingRooms = this.props.postingRooms;
-      if (_postingRooms.length > 0) {
-        //Remove duplicates
-        _postingRooms.sort();
-        alert(_postingRooms.length);
-        /*
-        for(let i = 0, n = _postingRooms.length; i <= n -1; i++) {
-          if(_postingRooms[i].threadId == _postingRooms[i+1].threadId) {
-            _postingRooms.splice(i,1);
-            n--;
-            i--;
-          }
-        }*/
-      }
-
-      this.setState({
-        postingRooms: _postingRooms
-      })
     }
 
     this.dispatchActions();

--- a/components/SubmitInstance/SubmitInstance.jsx
+++ b/components/SubmitInstance/SubmitInstance.jsx
@@ -96,6 +96,25 @@ export class SubmitInstance extends Component {
       ) {
         return;
       }
+
+      let _postingRooms = this.props.postingRooms;
+      if (_postingRooms.length > 0) {
+        //Remove duplicates
+        _postingRooms.sort();
+        alert(_postingRooms.length);
+        /*
+        for(let i = 0, n = _postingRooms.length; i <= n -1; i++) {
+          if(_postingRooms[i].threadId == _postingRooms[i+1].threadId) {
+            _postingRooms.splice(i,1);
+            n--;
+            i--;
+          }
+        }*/
+      }
+
+      this.setState({
+        postingRooms: _postingRooms
+      })
     }
 
     this.dispatchActions();

--- a/components/TableInstance/TableInstance.jsx
+++ b/components/TableInstance/TableInstance.jsx
@@ -86,6 +86,17 @@ class TableInstance extends Component {
             </thead>
             <tbody>
               {this.props.instanceList.map((item, index) => {
+                //Validate posting location Rooms
+                let _postingLocationRooms = item.postingLocationRooms;
+                _postingLocationRooms.sort();
+                for(let i = 0, n = _postingLocationRooms.length; i < n-1; i++) {
+                  if(_postingLocationRooms[i].threadId === _postingLocationRooms[i+1].threadId) {
+                    _postingLocationRooms.splice(i,1);
+                    i--;
+                    n--;
+                  }
+                }
+
                 const _instance = {
                   name: item.name,
                   appName: this.props.appName,
@@ -93,7 +104,7 @@ class TableInstance extends Component {
                   streamType: item.streamType,
                   instanceId: item.instanceId,
                   baseWebHookURL: this.props.baseWebHookURL,
-                  postingLocationRooms: item.postingLocationRooms,
+                  postingLocationRooms: _postingLocationRooms,
                   lastPosted: item.lastPosted,
                 };
                 return (

--- a/components/TableInstance/TableInstance.jsx
+++ b/components/TableInstance/TableInstance.jsx
@@ -87,15 +87,14 @@ class TableInstance extends Component {
             <tbody>
               {this.props.instanceList.map((item, index) => {
                 //Validate posting location Rooms
-                let _postingLocationRooms = item.postingLocationRooms;
-                _postingLocationRooms.sort();
-                for(let i = 0, n = _postingLocationRooms.length; i < n-1; i++) {
-                  if(_postingLocationRooms[i].threadId === _postingLocationRooms[i+1].threadId) {
-                    _postingLocationRooms.splice(i,1);
-                    i--;
-                    n--;
-                  }
+                let _postingLocationRooms = {};
+                for(let i = 0; i < item.postingLocationRooms.length; i++) {
+                  _postingLocationRooms[item.postingLocationRooms[i].threadId] = item.postingLocationRooms[i];
                 }
+
+                let uniqueArray = item.postingLocationRooms.filter(item => {
+                  return !(_postingLocationRooms.hasOwnProperty(item.threadId));
+                })
 
                 const _instance = {
                   name: item.name,
@@ -104,7 +103,7 @@ class TableInstance extends Component {
                   streamType: item.streamType,
                   instanceId: item.instanceId,
                   baseWebHookURL: this.props.baseWebHookURL,
-                  postingLocationRooms: _postingLocationRooms,
+                  postingLocationRooms: uniqueArray,
                   lastPosted: item.lastPosted,
                 };
                 return (


### PR DESCRIPTION
…and fixed same room appearing on description of integration. Also created a redudancy that doesnt allow two instance of the same posting locations to be sent to MongoDB

-> If a room is already assigned to an integration, it wont show on the suggestion list
-> If, for some reason, the same room is assigned twice or more to an integration it wont be shown on the "Active In" table view, also the same room wont be sent twice to the database.